### PR TITLE
Set instance variable values at initialization and remove unused variables to avoid spamming rake warnings.

### DIFF
--- a/lib/rly/lex.rb
+++ b/lib/rly/lex.rb
@@ -61,6 +61,8 @@ module Rly
     #   puts "#{tok.type} -> #{tok.value}" #=> "UPPERS -> WORLD"
     #   t = lex.next # => nil
     def initialize(input="")
+      @token_regexps = nil
+
       @input = input
       @pos = 0
       @lineno = 0

--- a/lib/rly/parse/lr_table.rb
+++ b/lib/rly/parse/lr_table.rb
@@ -81,7 +81,7 @@ module Rly
                     # Need to decide on shift or reduce here
                     # By default we favor shifting. Need to add
                     # some precedence rules here.
-                    sprec, slevel = productions[st_actionp[a].index].precedence
+                    _, slevel = productions[st_actionp[a].index].precedence
                     rprec, rlevel = precedence[a] || [:right, 0]
                     if (slevel < rlevel) || ((slevel == rlevel) && (rprec == :left))
                       # We really need to reduce here.
@@ -149,7 +149,7 @@ module Rly
                     #   -  if precedence of reduce is same and left assoc, we reduce.
                     #   -  otherwise we shift
                     rprec, rlevel = productions[st_actionp[a].index].precedence
-                    sprec, slevel = precedence[a] || [:right, 0]
+                    _, slevel = precedence[a] || [:right, 0]
                     if (slevel > rlevel) || ((slevel == rlevel) && (rprec == :right))
                       # We decide to shift here... highest precedence to shift
                       productions[st_actionp[a].index].reduced -= 1
@@ -368,7 +368,6 @@ module Rly
     end
 
     def dr_relation(c, trans, nullable)
-      dr_set = {}
       state, n = trans
       terms = []
 

--- a/lib/rly/parse/rule_parser.rb
+++ b/lib/rly/parse/rule_parser.rb
@@ -4,6 +4,13 @@ require "rly/parse/lr_table"
 
 module Rly
   class RuleParser < Yacc
+
+    def initialize
+      super
+      @grammar = nil
+      @lexer_class = nil
+    end
+
     def self.lexer_class
       return @lexer_class if @lexer_class
 

--- a/lib/rly/yacc.rb
+++ b/lib/rly/yacc.rb
@@ -11,6 +11,9 @@ module Rly
     attr_reader :lex, :grammar, :lr_table
 
     def initialize(lex=nil)
+      @grammar = nil
+      @parsed_rules = nil
+
       raise ArgumentError.new("No lexer available") if lex == nil && self.class.lexer_class == nil
       @lex = lex || self.class.lexer_class.new
 


### PR DESCRIPTION
Fixes https://github.com/farcaller/rly/issues/2.